### PR TITLE
🔧 Fix slug modification and improve WordPress.org compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage.xml
 node_modules/
 package-lock.json
 .idea
+.cursorrules
+instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Architecture
+
+This is a WordPress plugin for creating custom post types and taxonomies. The plugin follows:
+
+- **PSR-4 autoloading** with namespace `Custom_PTT\` mapped to `includes/`
+- **Dependency injection** using PHP-DI container managed by `Container_Singleton`
+- **Registerable interface** pattern for services (`Infrastructure/Registerable.php`)
+- **WordPress VIP coding standards** with performance optimization and object caching
+- **Strict typing** with `declare(strict_types=1)` in all PHP files
+
+### Core Components
+
+- **Plugin.php** - Main plugin class that bootstraps services via DI container
+- **Container_Singleton.php** - Singleton pattern for dependency injection container
+- **Post_Type/Post_Type.php** - Handles custom post type registration with caching
+- **Taxonomy/Taxonomy.php** - Handles custom taxonomy registration with caching
+- **Admin/** - WordPress admin interface with form handlers and list tables
+- **Utilities.php** - Helper functions and utilities
+
+### Key Features
+
+- Object caching for performance (cache groups: `custom_ptt_post_types`, `custom_ptt_taxonomies`)
+- WordPress hooks for extensibility: `custom_ptt_taxonomy_args`, `custom_ptt_post_type_args`
+- VIP-compatible with comprehensive error handling and logging
+
+## Development Commands
+
+### PHP Development
+```bash
+# Install dependencies
+composer install
+
+# Code standards check
+composer phpcs
+
+# Auto-fix code standards
+composer phpcbf
+
+# Run unit tests
+composer unit
+
+# Generate test coverage
+composer coverage
+```
+
+### Frontend Development (TailwindCSS)
+```bash
+# Install Node.js dependencies
+npm install
+
+# Watch mode for CSS development
+npm run dev
+
+# Build production CSS
+npm run build
+```
+
+### WordPress Environment (wp-env)
+```bash
+# Start local development environment
+npm run start-env
+
+# Stop environment
+npm run stop-env
+
+# Install composer dependencies in wp-env
+npm run composer-install
+
+# Run PHPUnit tests in wp-env
+npm run test-php
+```
+
+## Code Standards
+
+- Follow **WordPress-VIP-Go** coding standards via PHPCS
+- Maintain **PHP 8.0+** compatibility
+- Use **strict typing** (`declare(strict_types=1)`)
+- Implement **object caching** for performance-critical operations
+- Follow **WordPress coding conventions** for file naming and structure
+
+## Testing
+
+- Unit tests located in `tests/unit/` using PHPUnit 9.6+
+- Bootstrap file: `tests/unit/bootstrap.php`
+- Coverage reports generated to `coverage/html/`
+- Tests follow WordPress VIP testing standards

--- a/README.md
+++ b/README.md
@@ -1,88 +1,86 @@
-# Custom post types and taxonomies (Custom PTT)
+=== Custom PTT ===
+Contributors: freibergergarcia
+Tags: custom post types, taxonomies, post types, custom taxonomies
+Requires at least: 5.8
+Tested up to: 6.8
+Requires PHP: 8.0
+Stable tag: 0.2.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-The Custom PTT plugin is a simple WordPress Plugin to extend the functionality of WordPress by creating Custom Taxonomies and Custom Post Types.
+A simple WordPress Plugin to extend the functionality of WordPress by creating Custom Taxonomies and Custom Post Types.
 
-![Unit Tests](https://github.com/freibergergarcia/custom-post-types-taxonomies/actions/workflows/run-phpunit.yml/badge.svg)
-![PHP Code Sniffer](https://github.com/freibergergarcia/custom-post-types-taxonomies/actions/workflows/run-phpcs.yml/badge.svg)
+== Description ==
 
-## Features
-
-Once the plugin is activate, it doesn't generate any code to be placced anywhere in the `theme` or `plugin` files.  
+Once the plugin is activated, it doesn't generate any code to be placed anywhere in the `theme` or `plugin` files.  
 
 **We initialize custom Post Types and custom Taxonomies by the use of WordPress hooks**.
 
+= Key Features =
+- WordPress VIP compatible
+- Performance optimized with object caching
+- Follows WordPress VIP coding standards
+- Comprehensive error handling and logging
 - Easily add Custom Taxonomies
 - Easily add Custom Post Types
-- Extend with a built-in filters and actions in case you would like to modify the default arguments
+- Extend with built-in filters and actions
 
-### Filters and Actions
+= Performance Features =
+- Object caching for taxonomy and post type registrations
+- Smart cache invalidation based on arguments
+- Optimized database queries
+- Proper error handling and logging
 
-#### Taxonomies
+= Filters and Actions =
 
-`custom_ptt_taxonomy_args` filter is available to modify the default arguments used when registering a taxonomy.
+== Taxonomies ==
+
 ```php 
-/**
- * Filters the arguments used when registering a taxonomy.
- *
- * @param array $args The arguments used when registering a taxonomy.
- * @param string $taxonomy_slug The taxonomy slug.
- * @param array $taxonomy_data The taxonomy data.
- * @since 0.1.0-alpha
- */
- $args = apply_filters( 'custom_ptt_taxonomy_args', $args, $taxonomy_slug, $taxonomy_data );
+// Modify taxonomy registration arguments
+apply_filters('custom_ptt_taxonomy_args', $args, $taxonomy_slug, $taxonomy_data);
+
+// After taxonomies are registered
+do_action('custom_ptt_registered_taxonomies', $taxonomies);
 ```
 
-`custom_ptt_registered_taxonomies` action fires after the taxonomies are registrered
+== Post Types ==
+
 ```php 
-/**
-* Fires after the taxonomies are registered.
-*
-* @param array $taxonomies The taxonomies that were registered.
-* @since 0.1.0-alpha
-*/
-do_action( 'custom_ptt_registered_taxonomies', $taxonomies );
+// Modify post type registration arguments
+apply_filters('custom_ptt_post_type_args', $args, $post_type_key, $post_type_data);
+
+// After post types are registered
+do_action('custom_ptt_registered_post_types', $post_types);
 ```
 
-#### Post Types
+== Installation ==
 
-`custom_ptt_post_type_args` filter is available to modify the default arguments used when registering a post type.
-```php 
-/**
-* Filters the arguments used when registering a post type.
-*
-* @param array $args The arguments used when registering a post type.
- * @param string $post_type_key The post type slug.
-* @param array $post_type_data The post type data.
-*
-* @since 0.1.0-alpha
-*/
-$args = apply_filters( 'custom_ptt_post_type_args', $args, $post_type_key, $post_type_data );
-```
-
-`custom_ptt_registered_post_types` action fires after the post types are registrered
-```php 
-/**
-* Fires after the post types are registered.
-*
-* @param array $post_types The post types that were registered.
-*
-* @since 0.1.0-alpha
-*/
-do_action( 'custom_ptt_registered_post_types', $post_types );
-```
-
-## Installation
-
-Composer install is all you need to get started.
-```
+```bash
 composer install
 ```
 
-## Contributing
+== Development ==
 
-Anyone is welcome to contribute to Custom PTT. Please follow our guidelines, which are specified on the [phpcs.xml.dist](phpcs.xml.dist) file.
-PR's should be raised to the `develop` branch.
+= Code Standards =
+```bash
+composer phpcs
+composer phpcbf  # Auto-fix
+```
 
-## License
+= Testing =
+```bash
+composer unit
+composer coverage
+```
 
-This project is licensed under the GNU General Public License v2.0 - see the [LICENSE](LICENSE) file for details.
+== Changelog ==
+
+= 0.2.0 =
+* Added Container Singleton pattern for dependency injection
+* Improved VIP compatibility and performance optimization
+* Enhanced error handling and logging
+* Added object caching for post types and taxonomies
+
+== License ==
+
+GNU General Public License v2.0 - see the [LICENSE](LICENSE) file for details.

--- a/assets/css/public/general.css
+++ b/assets/css/public/general.css
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-/*! tailwindcss v3.3.5 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v3.4.1 | MIT License | https://tailwindcss.com */
 /*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
@@ -23,16 +23,19 @@
 4. Use the user's configured `sans` font-family by default.
 5. Use the user's configured `sans` font-feature-settings by default.
 6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
 */
-html {
+html,
+:host {
   line-height: 1.5; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
   -moz-tab-size: 4; /* 3 */
   -o-tab-size: 4;
      tab-size: 4; /* 3 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 4 */
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 4 */
   font-feature-settings: normal; /* 5 */
   font-variation-settings: normal; /* 6 */
+  -webkit-tap-highlight-color: transparent; /* 7 */
 }
 /*
 1. Remove the margin in all browsers.
@@ -86,15 +89,19 @@ strong {
   font-weight: bolder;
 }
 /*
-1. Use the user's configured `mono` font family by default.
-2. Correct the odd `em` font sizing in all browsers.
+1. Use the user's configured `mono` font-family by default.
+2. Use the user's configured `mono` font-feature-settings by default.
+3. Use the user's configured `mono` font-variation-settings by default.
+4. Correct the odd `em` font sizing in all browsers.
 */
 code,
 kbd,
 samp,
 pre {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; /* 1 */
-  font-size: 1em; /* 2 */
+  font-feature-settings: normal; /* 2 */
+  font-variation-settings: normal; /* 3 */
+  font-size: 1em; /* 4 */
 }
 /*
 Add the correct font size in all browsers.
@@ -769,9 +776,6 @@ select {
 }
 .justify-center {
   justify-content: center;
-}
-.justify-between {
-  justify-content: space-between;
 }
 .rounded {
   border-radius: 0.25rem;

--- a/custom-post-types-taxonomies.php
+++ b/custom-post-types-taxonomies.php
@@ -3,11 +3,14 @@
  * Custom PTT Plugin.
  *
  * @package   Custom_PTT
- * @copyright Copyright (C) 2023-2024, Custom PTT
+ * @copyright Copyright (C) 2023-2025, Custom PTT
  * @link      https://www.github.com/freibergergarcia/custom-post-types-taxonomies
  * @license   http://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0
  *
  * @wordpress-plugin
+ * @vip-compatible
+ * @vip-go-compatible
+ * 
  * Plugin Name:       Custom PTT
  * Version:           0.2.0
  * Plugin URI:        https://www.github.com/freibergergarcia/custom-post-types-taxonomies
@@ -16,6 +19,7 @@
  * Author URI:        https://www.github.com/freibergergarcia
  * Domain Path:       /languages
  * Requires PHP:      8.0
+ * Requires WP:       5.8
  * Text Domain:       custom-post-types-taxonomies
  * License:           GNU General Public License v2.0
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
@@ -23,6 +27,7 @@
 
 declare( strict_types=1 );
 
+use Custom_PTT\Admin\Notices;
 use Custom_PTT\Container_Singleton;
 use Custom_PTT\Plugin_Factory;
 
@@ -55,6 +60,14 @@ if ( ! defined( 'CUSTOM_PTT_POST_TYPE_OPTION_NAME' ) ) {
 	define( 'CUSTOM_PTT_POST_TYPE_OPTION_NAME', 'custom_ptt_post_types' );
 }
 
+if ( ! defined( 'CUSTOM_PTT_VERSION' ) ) {
+	define( 'CUSTOM_PTT_VERSION', '0.2.0' );
+}
+
+if ( ! defined( 'CUSTOM_PTT_MIN_WP_VERSION' ) ) {
+	define( 'CUSTOM_PTT_MIN_WP_VERSION', '5.8' );
+}
+
 if ( class_exists( 'Custom_PTT\Plugin' ) ) {
 	register_uninstall_hook( __FILE__, array( 'Custom_PTT\Plugin', 'on_uninstall' ) );
 }
@@ -66,13 +79,21 @@ if ( class_exists( 'Custom_PTT\Plugin' ) ) {
  * @throws Exception
  */
 function bootstrap_plugin(): void {
+	// Check WordPress version
+	if ( version_compare( get_bloginfo( 'version' ), CUSTOM_PTT_MIN_WP_VERSION, '<' ) ) {
+		Notices::add_error(
+			sprintf(
+				/* translators: %s: WordPress version */
+				esc_html__( 'Custom PTT requires WordPress version %s or higher.', 'custom-post-types-taxonomies' ),
+				CUSTOM_PTT_MIN_WP_VERSION
+			)
+		);
+		return;
+	}
+
 	$container = Container_Singleton::get_instance();
 	Plugin_Factory::create( $container )
 		->boot();
 }
 
-try {
-	bootstrap_plugin();
-} catch ( Exception $e ) {
-
-}
+bootstrap_plugin();

--- a/includes/Admin/Post_Type_Form_Handler.php
+++ b/includes/Admin/Post_Type_Form_Handler.php
@@ -29,9 +29,9 @@ class Post_Type_Form_Handler implements Registerable {
 	 * @since 0.1.0-alpha
 	 */
 	public function register(): void {
-		add_filter( 'check_admin_referer', '__return_true' );
-		add_action( 'admin_post_custom_ptt_save_post_type', array( $this, 'handle_form_submission' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+		\add_filter( 'check_admin_referer', '__return_true' );
+		\add_action( 'admin_post_custom_ptt_save_post_type', array( $this, 'handle_form_submission' ) );
+		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 	}
 
 	/**
@@ -43,20 +43,17 @@ class Post_Type_Form_Handler implements Registerable {
 	 * @since 0.1.0-alpha
 	 */
 	public function handle_form_submission(): void {
-		if (
-			! isset( $_POST['custom_ptt_post_type_nonce'] )
-			|| ! wp_verify_nonce( $_POST['custom_ptt_post_type_nonce'], 'custom_ptt_save_post_type' )
-			|| ! check_admin_referer( 'custom_ptt_save_post_type', 'custom_ptt_post_type_nonce' )
-		) {
-			wp_die( esc_html__( 'Security check failed. Please try again.', 'custom-post-types-taxonomies' ) );
+		$nonce = isset( $_POST['custom_ptt_post_type_nonce'] ) ? \sanitize_key( $_POST['custom_ptt_post_type_nonce'] ) : '';
+		if ( ! $nonce || ! \wp_verify_nonce( $nonce, 'custom_ptt_save_post_type' ) ) {
+			\wp_die( \esc_html__( 'Security check failed. Please try again.', 'custom-post-types-taxonomies' ) );
 		}
 
 		$data = array(
-			'post_type_key'  => isset( $_POST['post-type-key'] ) ? sanitize_text_field( wp_unslash( $_POST['post-type-key'] ) ) : '',
-			'plural_label'   => isset( $_POST['plural-label'] ) ? sanitize_text_field( wp_unslash( $_POST['plural-label'] ) ) : '',
-			'singular_label' => isset( $_POST['singular-label'] ) ? sanitize_text_field( wp_unslash( $_POST['singular-label'] ) ) : '',
-			'post_type_slug' => isset( $_POST['post-type-slug'] ) ? sanitize_text_field( wp_unslash( $_POST['post-type-slug'] ) ) : '',
-			'taxonomies'     => isset( $_POST['taxonomies'] ) && is_array( $_POST['taxonomies'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['taxonomies'] ) ) : array(),
+			'post_type_key'  => isset( $_POST['post-type-key'] ) ? \sanitize_text_field( \wp_unslash( $_POST['post-type-key'] ) ) : '',
+			'plural_label'   => isset( $_POST['plural-label'] ) ? \sanitize_text_field( \wp_unslash( $_POST['plural-label'] ) ) : '',
+			'singular_label' => isset( $_POST['singular-label'] ) ? \sanitize_text_field( \wp_unslash( $_POST['singular-label'] ) ) : '',
+			'post_type_slug' => isset( $_POST['post-type-slug'] ) ? \sanitize_text_field( \wp_unslash( $_POST['post-type-slug'] ) ) : '',
+			'taxonomies'     => isset( $_POST['taxonomies'] ) && is_array( $_POST['taxonomies'] ) ? array_map( '\sanitize_text_field', \wp_unslash( $_POST['taxonomies'] ) ) : array(),
 		);
 
 		try {
@@ -67,23 +64,24 @@ class Post_Type_Form_Handler implements Registerable {
 
 			$store_post_type = $this->store_post_type( $data );
 			if ( ! array_key_exists( $data['post_type_key'], $store_post_type ) ) {
-				throw new Exception( esc_html__( 'An error occurred while saving the post type.', 'custom-post-types-taxonomies' ) );
+				throw new Exception( \esc_html__( 'An error occurred while saving the post type.', 'custom-post-types-taxonomies' ) );
 			}
 
 			Notices::add_admin_notice(
 				'success',
-				esc_html__( 'Post Type updated successfully.', 'custom-post-types-taxonomies' )
+				\esc_html__( 'Post Type updated successfully.', 'custom-post-types-taxonomies' )
 			);
-			wp_redirect( admin_url( 'admin.php?page=custom-post-types-taxonomies-post-types&status=success' ) );
+			\wp_redirect( \admin_url( 'admin.php?page=custom-post-types-taxonomies-post-types&status=success' ) );
+			exit;
 
 		} catch ( Exception $e ) {
 			Notices::add_admin_notice(
 				'error',
 				$e->getMessage()
 			);
-			wp_redirect( admin_url( 'admin.php?page=custom-post-types-taxonomies-post-types&status=error' ) );
+			\wp_redirect( \admin_url( 'admin.php?page=custom-post-types-taxonomies-post-types&status=error' ) );
+			exit;
 		}
-		exit;
 	}
 
 	/**
@@ -106,9 +104,10 @@ class Post_Type_Form_Handler implements Registerable {
 			'rewrite'      => array( 'slug' => $data['post_type_slug'] ),
 			'public'       => true,
 			'show_in_rest' => true,
+			'taxonomies'   => $data['taxonomies'] ?? array(),
 		);
 
-		return register_post_type( $data['post_type_key'], $args );
+		return \register_post_type( $data['post_type_key'], $args );
 	}
 
 	/**
@@ -121,12 +120,12 @@ class Post_Type_Form_Handler implements Registerable {
 	 * @since 0.1.0-alpha
 	 */
 	private function store_post_type( array $data ): array {
-		$post_types                           = get_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, array() );
+		$post_types                           = \get_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, array() );
 		$post_types[ $data['post_type_key'] ] = $data;
 
-		update_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, $post_types );
+		\update_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, $post_types );
 
-		return get_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, array() );
+		return \get_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, array() );
 	}
 
 	/**
@@ -137,10 +136,10 @@ class Post_Type_Form_Handler implements Registerable {
 	 * @since 0.1.0-alpha
 	 */
 	public function enqueue_styles(): void {
-		$screen = get_current_screen();
+		$screen = \get_current_screen();
 
 		if ( isset( $screen->id ) && 'custom-ptt_page_add-custom-post-types-taxonomies-post-types' === $screen->id ) {
-			wp_enqueue_style(
+			\wp_enqueue_style(
 				'custom-ptt-general',
 				CUSTOM_PTT_URL . './assets/css/public/general.css',
 				array(),

--- a/includes/Admin/Post_Type_Form_Handler.php
+++ b/includes/Admin/Post_Type_Form_Handler.php
@@ -53,7 +53,7 @@ class Post_Type_Form_Handler implements Registerable {
 			'plural_label'   => isset( $_POST['plural-label'] ) ? \sanitize_text_field( \wp_unslash( $_POST['plural-label'] ) ) : '',
 			'singular_label' => isset( $_POST['singular-label'] ) ? \sanitize_text_field( \wp_unslash( $_POST['singular-label'] ) ) : '',
 			'post_type_slug' => isset( $_POST['post-type-slug'] ) ? \sanitize_text_field( \wp_unslash( $_POST['post-type-slug'] ) ) : '',
-			'taxonomies'     => isset( $_POST['taxonomies'] ) && is_array( $_POST['taxonomies'] ) ? array_map( '\sanitize_text_field', \wp_unslash( $_POST['taxonomies'] ) ) : array(),
+			'taxonomies'     => $this->sanitize_taxonomy_array(),
 		);
 
 		try {
@@ -147,5 +147,26 @@ class Post_Type_Form_Handler implements Registerable {
 				'all'
 			);
 		}
+	}
+
+	/**
+	 * Sanitize taxonomy array from POST data.
+	 *
+	 * @return array
+	 * @since 0.2.1
+	 */
+	private function sanitize_taxonomy_array(): array {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled in handle_form_submission
+		if ( ! isset( $_POST['taxonomies'] ) || ! is_array( $_POST['taxonomies'] ) ) {
+			return array();
+		}
+
+		$sanitized_taxonomies = array();
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verification is handled in handle_form_submission, sanitization is done below
+		foreach ( \wp_unslash( $_POST['taxonomies'] ) as $taxonomy ) {
+			$sanitized_taxonomies[] = \sanitize_text_field( $taxonomy );
+		}
+
+		return $sanitized_taxonomies;
 	}
 }

--- a/includes/Admin/Post_Type_Form_Page.php
+++ b/includes/Admin/Post_Type_Form_Page.php
@@ -81,7 +81,7 @@ class Post_Type_Form_Page implements Registerable {
 	 * @since 0.1.0-alpha
 	 */
 	public function render_form(): void {
-		$post_type_name = isset( $_GET['custom_post_type'] ) ? sanitize_text_field( $_GET['custom_post_type'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_type_name = isset( $_GET['custom_post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['custom_post_type'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$post_type_data = null;
 		$post_type      = get_post_type_object( $post_type_name );

--- a/includes/Admin/Taxonomy_Form_Handler.php
+++ b/includes/Admin/Taxonomy_Form_Handler.php
@@ -47,7 +47,7 @@ class Taxonomy_Form_Handler implements Registerable {
 
 		if (
 			! isset( $_POST['custom_ptt_taxonomy_nonce'] )
-			|| ! wp_verify_nonce( $_POST['custom_ptt_taxonomy_nonce'], 'custom_ptt_save_taxonomy' )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['custom_ptt_taxonomy_nonce'] ) ), 'custom_ptt_save_taxonomy' )
 			|| ! check_admin_referer( 'custom_ptt_save_taxonomy', 'custom_ptt_taxonomy_nonce' )
 		) {
 			wp_die( esc_html__( 'Security check failed. Please try again.', 'custom-post-types-taxonomies' ) );
@@ -76,6 +76,7 @@ class Taxonomy_Form_Handler implements Registerable {
 				esc_html__( 'Taxonomy updated successfully.', 'custom-post-types-taxonomies' )
 			);
 			wp_redirect( admin_url( 'admin.php?page=custom-post-types-taxonomies&status=success' ) );
+			exit;
 
 		} catch ( Exception $e ) {
 			Notices::add_admin_notice(
@@ -83,8 +84,8 @@ class Taxonomy_Form_Handler implements Registerable {
 				$e->getMessage()
 			);
 			wp_redirect( admin_url( 'admin.php?page=custom-post-types-taxonomies&status=error' ) );
+			exit;
 		}
-		exit;
 	}
 
 	/**

--- a/includes/Admin/Taxonomy_Form_Page.php
+++ b/includes/Admin/Taxonomy_Form_Page.php
@@ -81,7 +81,7 @@ class Taxonomy_Form_Page implements Registerable {
 	 * @throws Exception
 	 */
 	public function render_form(): void {
-		$taxonomy_name = isset( $_GET['taxonomy'] ) ? sanitize_text_field( $_GET['taxonomy'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$taxonomy_name = isset( $_GET['taxonomy'] ) ? sanitize_text_field( wp_unslash( $_GET['taxonomy'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$taxonomy_data = null;
 		$taxonomy      = get_taxonomy( $taxonomy_name );

--- a/includes/Admin/Taxonomy_List_Table.php
+++ b/includes/Admin/Taxonomy_List_Table.php
@@ -87,10 +87,10 @@ class Taxonomy_List_Table extends WP_List_Table {
 		$order   = 'asc';
 		if (
 			isset( $_REQUEST['custom_ptt_taxonomy_nonce'] ) &&
-			wp_verify_nonce( $_REQUEST['custom_ptt_taxonomy_nonce'], 'custom_ptt_save_taxonomy' )
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['custom_ptt_taxonomy_nonce'] ) ), 'custom_ptt_save_taxonomy' )
 		) {
-			$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'name';
-			$order   = isset( $_GET['order'] ) ? sanitize_text_field( $_GET['order'] ) : 'asc';
+			$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : 'name';
+			$order   = isset( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : 'asc';
 		}
 
 		$taxonomies = get_taxonomies( array( '_builtin' => false ), 'objects' );

--- a/includes/Admin/templates/custom-ptt-post-types-form.php
+++ b/includes/Admin/templates/custom-ptt-post-types-form.php
@@ -14,10 +14,10 @@
 		<?php
 		if (
 			isset( $_REQUEST['custom_ptt_post_type_nonce'] ) &&
-			wp_verify_nonce( $_REQUEST['custom_ptt_post_type_nonce'], 'custom_ptt_save_post_type' ) &&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['custom_ptt_post_type_nonce'] ) ), 'custom_ptt_save_post_type' ) &&
 			is_null( $post_type_data ) &&
 			isset( $_GET['action'] ) &&
-			'edit' === sanitize_text_field( $_GET['action'] )
+			'edit' === sanitize_text_field( wp_unslash( $_GET['action'] ) )
 		) {
 			?>
 
@@ -34,7 +34,7 @@
 
 			<div class="mt-10 w-full">
 				<h1 class="text-2xl font-bold mb-6">
-					<?php echo ! empty( $post_type_data ) ? esc_html__( 'Edit Post Type', 'custom-post-types-post-types' ) : esc_html__( 'Add New Post Type', 'custom-post-types-post-types' ); ?>
+					<?php echo ! empty( $post_type_data ) ? esc_html__( 'Edit Post Type', 'custom-post-types-taxonomies' ) : esc_html__( 'Add New Post Type', 'custom-post-types-taxonomies' ); ?>
 				</h1>
 
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 max-w-2xl mx-auto">
@@ -42,22 +42,30 @@
 					<input type="hidden" name="action" value="custom_ptt_save_post_type">
 
 					<div class="mb-4">
-						<label for="post-type-slug" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Post Type slug:', 'custom-post-types-post-types' ); ?></label>
-						<input type="text" id="post-type-slug" name="post-type-slug" value="<?php echo esc_attr( $post_type_data['post_type_slug'] ?? '' ); ?>" class="form-input w-full" required>
+						<label class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Post Type slug:', 'custom-post-types-taxonomies' ); ?></label>
+						<?php if ( ! empty( $post_type_data ) ) : ?>
+							<div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 text-gray-700">
+								<code><?php echo esc_html( $post_type_data['post_type_slug'] ); ?></code>
+							</div>
+							<p class="text-xs text-gray-500 mt-1"><?php esc_html_e( 'The slug cannot be changed after creation to prevent data loss.', 'custom-post-types-taxonomies' ); ?></p>
+						<?php else : ?>
+							<input type="text" id="post-type-slug" name="post-type-slug" value="" class="form-input w-full" required>
+							<p class="text-xs text-gray-500 mt-1"><?php esc_html_e( 'This will be the permanent identifier for your post type.', 'custom-post-types-taxonomies' ); ?></p>
+						<?php endif; ?>
 					</div>
 
 					<div class="mb-4">
-						<label for="plural-label" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Plural Label:', 'custom-post-types-post-types' ); ?></label>
+						<label for="plural-label" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Plural Label:', 'custom-post-types-taxonomies' ); ?></label>
 						<input type="text" id="plural-label" name="plural-label" value="<?php echo esc_attr( $post_type_data['plural_label'] ?? '' ); ?>" class="form-input w-full">
 					</div>
 
 					<div class="mb-4">
-						<label for="singular-label" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Singular Label:', 'custom-post-types-post-types' ); ?></label>
+						<label for="singular-label" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Singular Label:', 'custom-post-types-taxonomies' ); ?></label>
 						<input type="text" id="singular-label" name="singular-label" value="<?php echo esc_attr( $post_type_data['singular_label'] ?? '' ); ?>" class="form-input w-full" required>
 					</div>
 
 					<div class="mb-4">
-						<label for="post-type-key" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Post Type Key:', 'custom-post-types-post-types' ); ?></label>
+						<label for="post-type-key" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Post Type Key:', 'custom-post-types-taxonomies' ); ?></label>
 						<input type="text" id="post-type-key" name="post-type-key" 
 						<?php
 						if ( ! empty( $post_type_data['post_type_key'] ) ) {
@@ -70,27 +78,32 @@
 					</div>
 
 					<div class="mb-6">
-						<label class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Attach to Taxonomies:', 'custom-post-types-post-types' ); ?></label>
+						<label class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Attach to Taxonomies:', 'custom-post-types-taxonomies' ); ?></label>
 						<div class="flex flex-col pl-4">
 							<?php
 							foreach ( $taxonomies as $taxonomy_slug => $taxonomy ) {
 								if ( ! $taxonomy instanceof WP_Taxonomy ) {
 									continue;
 								}
-
 								?>
 								<div class="mb-2">
-									<input type="checkbox" id="taxonomy-<?php echo esc_attr( $taxonomy->rewrite->slug ); ?>" name="taxonomies[]" value="<?php echo esc_attr( $taxonomy->rewrite->slug ); ?>" <?php checked( in_array( $taxonomy->rewrite->slug, $post_type_data['taxonomies'] ?? array(), true ) ); ?> class="form-checkbox">
-									<label for="taxonomy-<?php echo esc_attr( $taxonomy->rewrite->slug ); ?>" class="text-sm"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
+									<input type="checkbox" 
+										id="taxonomy-<?php echo esc_attr( $taxonomy_slug ); ?>" 
+										name="taxonomies[]" 
+										value="<?php echo esc_attr( $taxonomy_slug ); ?>" 
+										<?php checked( in_array( $taxonomy_slug, $post_type_data['taxonomies'] ?? array(), true ) ); ?> 
+										class="form-checkbox">
+									<label for="taxonomy-<?php echo esc_attr( $taxonomy_slug ); ?>" 
+										class="text-sm"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
 								</div>
 							<?php } ?>
 						</div>
 					</div>
 
 					<?php if ( isset( $post_type_data ) ) { ?>
-						<?php submit_button( esc_attr__( 'Update Post Type', 'custom-post-types-post-types' ), 'primary bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline', 'submit', false ); ?>
+						<?php submit_button( esc_attr__( 'Update Post Type', 'custom-post-types-taxonomies' ), 'primary bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline', 'submit', false ); ?>
 					<?php } else { ?>
-						<?php submit_button( esc_attr__( 'Add Post Type', 'custom-post-types-post-types' ), 'primary bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline', 'submit', false ); ?>
+						<?php submit_button( esc_attr__( 'Add Post Type', 'custom-post-types-taxonomies' ), 'primary bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline', 'submit', false ); ?>
 					<?php } ?>
 
 				</form>

--- a/includes/Admin/templates/custom-ptt-post-types-form.php
+++ b/includes/Admin/templates/custom-ptt-post-types-form.php
@@ -81,8 +81,8 @@
 						<label class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Attach to Taxonomies:', 'custom-post-types-taxonomies' ); ?></label>
 						<div class="flex flex-col pl-4">
 							<?php
-							foreach ( $taxonomies as $taxonomy_slug => $taxonomy ) {
-								if ( ! $taxonomy instanceof WP_Taxonomy ) {
+							foreach ( $taxonomies as $taxonomy_slug => $taxonomy_obj ) {
+								if ( ! $taxonomy_obj instanceof WP_Taxonomy ) {
 									continue;
 								}
 								?>
@@ -94,7 +94,7 @@
 										<?php checked( in_array( $taxonomy_slug, $post_type_data['taxonomies'] ?? array(), true ) ); ?> 
 										class="form-checkbox">
 									<label for="taxonomy-<?php echo esc_attr( $taxonomy_slug ); ?>" 
-										class="text-sm"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
+										class="text-sm"><?php echo esc_html( $taxonomy_obj->labels->singular_name ); ?></label>
 								</div>
 							<?php } ?>
 						</div>

--- a/includes/Admin/templates/custom-ptt-post-types-form.php
+++ b/includes/Admin/templates/custom-ptt-post-types-form.php
@@ -47,6 +47,7 @@
 							<div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 text-gray-700">
 								<code><?php echo esc_html( $post_type_data['post_type_slug'] ); ?></code>
 							</div>
+							<input type="hidden" name="post-type-slug" value="<?php echo esc_attr( $post_type_data['post_type_slug'] ); ?>">
 							<p class="text-xs text-gray-500 mt-1"><?php esc_html_e( 'The slug cannot be changed after creation to prevent data loss.', 'custom-post-types-taxonomies' ); ?></p>
 						<?php else : ?>
 							<input type="text" id="post-type-slug" name="post-type-slug" value="" class="form-input w-full" required>

--- a/includes/Admin/templates/custom-ptt-post-types-form.php
+++ b/includes/Admin/templates/custom-ptt-post-types-form.php
@@ -42,7 +42,7 @@
 					<input type="hidden" name="action" value="custom_ptt_save_post_type">
 
 					<div class="mb-4">
-						<label class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Post Type slug:', 'custom-post-types-taxonomies' ); ?></label>
+						<label for="post-type-slug" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Post Type slug:', 'custom-post-types-taxonomies' ); ?></label>
 						<?php if ( ! empty( $post_type_data ) ) : ?>
 							<div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 text-gray-700">
 								<code><?php echo esc_html( $post_type_data['post_type_slug'] ); ?></code>

--- a/includes/Admin/templates/custom-ptt-taxonomies-form.php
+++ b/includes/Admin/templates/custom-ptt-taxonomies-form.php
@@ -11,12 +11,13 @@
 
 	<div class="wrap max-w-lg mx-auto">
 		<?php
+		$nonce = isset( $_REQUEST['custom_ptt_taxonomy_nonce'] ) ? sanitize_key( $_REQUEST['custom_ptt_taxonomy_nonce'] ) : '';
 		if (
-			isset( $_REQUEST['custom_ptt_taxonomy_nonce'] ) &&
-			wp_verify_nonce( $_REQUEST['custom_ptt_taxonomy_nonce'], 'custom_ptt_save_taxonomy' ) &&
+			$nonce &&
+			wp_verify_nonce( $nonce, 'custom_ptt_save_taxonomy' ) &&
 			is_null( $taxonomy_data ) &&
 			isset( $_GET['action'] ) &&
-			'edit' === sanitize_text_field( $_GET['action'] )
+			'edit' === sanitize_text_field( wp_unslash( $_GET['action'] ) )
 		) {
 			?>
 
@@ -41,8 +42,16 @@
 					<input type="hidden" name="action" value="custom_ptt_save_taxonomy">
 
 					<div class="mb-4">
-						<label for="taxonomy-slug" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Taxonomy slug:', 'custom-post-types-taxonomies' ); ?></label>
-						<input type="text" id="taxonomy-slug" name="taxonomy-slug" value="<?php echo esc_attr( $taxonomy_data['taxonomy_slug'] ?? '' ); ?>" class="form-input w-full" required>
+						<label class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Taxonomy slug:', 'custom-post-types-taxonomies' ); ?></label>
+						<?php if ( ! empty( $taxonomy_data ) ) : ?>
+							<div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 text-gray-700">
+								<code><?php echo esc_html( $taxonomy_data['taxonomy_slug'] ); ?></code>
+							</div>
+							<p class="text-xs text-gray-500 mt-1"><?php esc_html_e( 'The slug cannot be changed after creation to prevent data loss.', 'custom-post-types-taxonomies' ); ?></p>
+						<?php else : ?>
+							<input type="text" id="taxonomy-slug" name="taxonomy-slug" value="" class="form-input w-full" required>
+							<p class="text-xs text-gray-500 mt-1"><?php esc_html_e( 'This will be the permanent identifier for your taxonomy.', 'custom-post-types-taxonomies' ); ?></p>
+						<?php endif; ?>
 					</div>
 
 					<!-- Plural Label -->

--- a/includes/Admin/templates/custom-ptt-taxonomies-form.php
+++ b/includes/Admin/templates/custom-ptt-taxonomies-form.php
@@ -47,6 +47,7 @@
 							<div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 text-gray-700">
 								<code><?php echo esc_html( $taxonomy_data['taxonomy_slug'] ); ?></code>
 							</div>
+							<input type="hidden" name="taxonomy-slug" value="<?php echo esc_attr( $taxonomy_data['taxonomy_slug'] ); ?>">
 							<p class="text-xs text-gray-500 mt-1"><?php esc_html_e( 'The slug cannot be changed after creation to prevent data loss.', 'custom-post-types-taxonomies' ); ?></p>
 						<?php else : ?>
 							<input type="text" id="taxonomy-slug" name="taxonomy-slug" value="" class="form-input w-full" required>

--- a/includes/Admin/templates/custom-ptt-taxonomies-form.php
+++ b/includes/Admin/templates/custom-ptt-taxonomies-form.php
@@ -42,7 +42,7 @@
 					<input type="hidden" name="action" value="custom_ptt_save_taxonomy">
 
 					<div class="mb-4">
-						<label class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Taxonomy slug:', 'custom-post-types-taxonomies' ); ?></label>
+						<label for="taxonomy-slug" class="block text-gray-700 text-sm font-bold mb-2"><?php esc_html_e( 'Taxonomy slug:', 'custom-post-types-taxonomies' ); ?></label>
 						<?php if ( ! empty( $taxonomy_data ) ) : ?>
 							<div class="bg-gray-50 border border-gray-300 rounded px-3 py-2 text-gray-700">
 								<code><?php echo esc_html( $taxonomy_data['taxonomy_slug'] ); ?></code>

--- a/includes/Admin/templates/custom-ptt-taxonomies-form.php
+++ b/includes/Admin/templates/custom-ptt-taxonomies-form.php
@@ -73,16 +73,16 @@
 							<?php
 							$post_types = get_post_types( array( 'public' => true ), 'objects' ); // Retrieve post types as objects to access labels
 
-							foreach ( $post_types as $post_type ) {
-								if ( in_array( $post_type->name, array( 'attachment', 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request', 'wp_block' ), true ) ) {
+							foreach ( $post_types as $post_type_obj ) {
+								if ( in_array( $post_type_obj->name, array( 'attachment', 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request', 'wp_block' ), true ) ) {
 									continue;
 								}
 
-								$is_checked = in_array( $post_type->name, $taxonomy_data['post_type'] ?? array(), true );
+								$is_checked = in_array( $post_type_obj->name, $taxonomy_data['post_type'] ?? array(), true );
 								?>
 							<div class="mb-2">
-								<input type="checkbox" id="post-type-<?php echo esc_attr( $post_type->name ); ?>" name="post-type[]" value="<?php echo esc_attr( $post_type->name ); ?>" <?php checked( $is_checked ); ?> class="form-checkbox">
-								<label for="post-type-<?php echo esc_attr( $post_type->name ); ?>" class="text-sm"><?php echo esc_html( $post_type->labels->singular_name ); ?></label>
+								<input type="checkbox" id="post-type-<?php echo esc_attr( $post_type_obj->name ); ?>" name="post-type[]" value="<?php echo esc_attr( $post_type_obj->name ); ?>" <?php checked( $is_checked ); ?> class="form-checkbox">
+								<label for="post-type-<?php echo esc_attr( $post_type_obj->name ); ?>" class="text-sm"><?php echo esc_html( $post_type_obj->labels->singular_name ); ?></label>
 							</div>
 								<?php
 							}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -113,7 +113,6 @@ class Plugin {
 	 */
 	public function on_deactivation(): void {
 		wp_cache_flush();
-		flush_rewrite_rules();
 	}
 
 	/**

--- a/includes/Post_Type/Post_Type.php
+++ b/includes/Post_Type/Post_Type.php
@@ -119,7 +119,7 @@ class Post_Type implements Registerable {
 			'singular_name' => $post_type_data['singular_label'],
 		);
 
-		$args = array(
+		$default_args = array(
 			'labels'            => $labels,
 			'public'            => true,
 			'show_in_rest'      => true,
@@ -127,7 +127,7 @@ class Post_Type implements Registerable {
 			'show_in_nav_menus' => true,
 		);
 		
-		$args = wp_parse_args( $post_type_data, $args );
+		$args = wp_parse_args( $post_type_data, $default_args );
 
 		/**
 		 * Filters the arguments used when registering a post type.

--- a/includes/Post_Type/Post_Type.php
+++ b/includes/Post_Type/Post_Type.php
@@ -66,7 +66,7 @@ class Post_Type implements Registerable {
 				$this->register_single_post_type( $post_type_key, $post_type_data );
 			} catch ( Exception $e ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					error_log(
+					error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 						sprintf( 
 							'Custom PTT Plugin - Error registering post type %s: %s', 
 							$post_type_key, 
@@ -139,7 +139,7 @@ class Post_Type implements Registerable {
 		 */
 		$args = apply_filters( 'custom_ptt_post_type_args', $args, $post_type_key, $post_type_data );
 		
-		$args_hash   = md5( serialize( $args ) );
+		$args_hash   = md5( wp_json_encode( $args ) );
 		$cache_key   = "post_type_{$post_type_key}_{$args_hash}";
 		$cached_args = wp_cache_get( $cache_key, self::CACHE_GROUP );
 		

--- a/includes/Post_Type/Post_Type.php
+++ b/includes/Post_Type/Post_Type.php
@@ -13,9 +13,16 @@ use WP_Error;
  *
  * @package   Custom_PTT
  * @since     0.1.0-alpha
- * @see       https://developer.wordpress.org/plugins/taxonomies/
+ * @see       https://developer.wordpress.org/plugins/post-types/
  */
 class Post_Type implements Registerable {
+
+	/**
+	 * Cache group for post types.
+	 *
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'custom_ptt_post_types';
 
 	/**
 	 * Register the post type.
@@ -43,41 +50,31 @@ class Post_Type implements Registerable {
 	 * @since 0.1.0-alpha
 	 */
 	public function register_post_type_on_init(): void {
-		$post_types = get_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, array() );
+		$post_types = wp_cache_get( 'registered_post_types', self::CACHE_GROUP );
+		
+		if ( false === $post_types ) {
+			$post_types = get_option( CUSTOM_PTT_POST_TYPE_OPTION_NAME, array() );
+			wp_cache_set( 'registered_post_types', $post_types, self::CACHE_GROUP, HOUR_IN_SECONDS );
+		}
+
 		if ( empty( $post_types ) ) {
 			return;
 		}
 
 		foreach ( $post_types as $post_type_key => $post_type_data ) {
-			$labels = array(
-				'name'          => $post_type_data['plural_label'],
-				'singular_name' => $post_type_data['singular_label'],
-			);
-
-			$args = array(
-				'labels'            => $labels,
-				'public'            => true,
-				'show_in_rest'      => true,
-				'show_in_admin_bar' => true,
-				'show_in_nav_menus' => true,
-			);
-			$args = wp_parse_args( $post_type_data, $args );
-
-			/**
-			 * Filters the arguments used when registering a post type.
-			 *
-			 * @param array $args The arguments used when registering a post type.
-			 * @param string $post_type_key The post type slug.
-			 * @param array $post_type_data The post type data.
-			 *
-			 * @since 0.1.0-alpha
-			 */
-			$args = apply_filters( 'custom_ptt_post_type_args', $args, $post_type_key, $post_type_data );
-
-			$post_type_result = register_post_type( $post_type_key, $args );
-
-			if ( $post_type_result instanceof WP_Error ) {
-				throw new Exception( $post_type_result->get_error_message() );
+			try {
+				$this->register_single_post_type( $post_type_key, $post_type_data );
+			} catch ( Exception $e ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					error_log(
+						sprintf( 
+							'Custom PTT Plugin - Error registering post type %s: %s', 
+							$post_type_key, 
+							$e->getMessage() 
+						) 
+					);
+				}
+				continue;
 			}
 		}
 
@@ -89,5 +86,68 @@ class Post_Type implements Registerable {
 		 * @since 0.1.0-alpha
 		 */
 		do_action( 'custom_ptt_registered_post_types', $post_types );
+	}
+
+	/**
+	 * Register a single post type.
+	 *
+	 * @param string $post_type_key The post type slug.
+	 * @param array  $post_type_data The post type data.
+	 * @throws Exception If post type registration fails.
+	 * @return void
+	 */
+	private function register_single_post_type( string $post_type_key, array $post_type_data ): void {
+		$args = $this->get_post_type_args( $post_type_key, $post_type_data );
+		
+		$post_type_result = register_post_type( $post_type_key, $args );
+
+		if ( $post_type_result instanceof WP_Error ) {
+			throw new Exception( esc_html( $post_type_result->get_error_message() ) );
+		}
+	}
+
+	/**
+	 * Get cached or fresh post type arguments.
+	 *
+	 * @param string $post_type_key The post type slug.
+	 * @param array  $post_type_data The post type data.
+	 * @return array
+	 */
+	private function get_post_type_args( string $post_type_key, array $post_type_data ): array {
+		$labels = array(
+			'name'          => $post_type_data['plural_label'],
+			'singular_name' => $post_type_data['singular_label'],
+		);
+
+		$args = array(
+			'labels'            => $labels,
+			'public'            => true,
+			'show_in_rest'      => true,
+			'show_in_admin_bar' => true,
+			'show_in_nav_menus' => true,
+		);
+		
+		$args = wp_parse_args( $post_type_data, $args );
+
+		/**
+		 * Filters the arguments used when registering a post type.
+		 *
+		 * @param array  $args           The arguments used when registering a post type.
+		 * @param string $post_type_key  The post type slug.
+		 * @param array  $post_type_data The post type data.
+		 * @since 0.1.0-alpha
+		 */
+		$args = apply_filters( 'custom_ptt_post_type_args', $args, $post_type_key, $post_type_data );
+		
+		$args_hash   = md5( serialize( $args ) );
+		$cache_key   = "post_type_{$post_type_key}_{$args_hash}";
+		$cached_args = wp_cache_get( $cache_key, self::CACHE_GROUP );
+		
+		if ( false === $cached_args ) {
+			wp_cache_set( $cache_key, $args, self::CACHE_GROUP, HOUR_IN_SECONDS );
+			return $args;
+		}
+
+		return $cached_args;
 	}
 }

--- a/includes/Taxonomy/Taxonomy.php
+++ b/includes/Taxonomy/Taxonomy.php
@@ -66,7 +66,7 @@ class Taxonomy implements Registerable {
 					$this->register_single_taxonomy( $taxonomy_slug, $taxonomy_data );
 				} catch ( Exception $e ) {
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-						error_log(
+						error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 							sprintf( 
 								'Custom PTT Plugin - Error registering taxonomy %s: %s', 
 								$taxonomy_slug, 
@@ -88,7 +88,7 @@ class Taxonomy implements Registerable {
 
 		} catch ( Exception $e ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				error_log(
+				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					sprintf( 
 						'Custom PTT Plugin - Error in taxonomy registration process: %s', 
 						$e->getMessage() 
@@ -134,7 +134,7 @@ class Taxonomy implements Registerable {
 		 */
 		$args = apply_filters( 'custom_ptt_taxonomy_args', $args, $taxonomy_slug, $taxonomy_data );
 		
-		$args_hash   = md5( serialize( $args ) );
+		$args_hash   = md5( wp_json_encode( $args ) );
 		$cache_key   = "taxonomy_{$taxonomy_slug}_{$args_hash}";
 		$cached_args = wp_cache_get( $cache_key, self::CACHE_GROUP );
 		

--- a/includes/Taxonomy/Taxonomy.php
+++ b/includes/Taxonomy/Taxonomy.php
@@ -113,7 +113,7 @@ class Taxonomy implements Registerable {
 			'singular_name' => $taxonomy_data['singular_label'],
 		);
 
-		$args = array(
+		$default_args = array(
 			'labels'            => $labels,
 			'public'            => true,
 			'show_ui'           => true,
@@ -122,7 +122,7 @@ class Taxonomy implements Registerable {
 			'show_in_rest'      => true,
 		);
 		
-		$args = wp_parse_args( $taxonomy_data, $args );
+		$args = wp_parse_args( $taxonomy_data, $default_args );
 
 		/**
 		 * Filters the arguments used when registering a taxonomy.

--- a/includes/Taxonomy/Taxonomy.php
+++ b/includes/Taxonomy/Taxonomy.php
@@ -20,6 +20,13 @@ use WP_Error;
 class Taxonomy implements Registerable {
 
 	/**
+	 * Cache group for taxonomies.
+	 *
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'custom_ptt_taxonomies';
+
+	/**
 	 * Register the taxonomy.
 	 *
 	 * @return void
@@ -42,51 +49,105 @@ class Taxonomy implements Registerable {
 	 * @since 0.1.0-alpha
 	 */
 	public function register_taxonomy_on_init(): void {
+		try {
+			$taxonomies = wp_cache_get( 'registered_taxonomies', self::CACHE_GROUP );
+			
+			if ( false === $taxonomies ) {
+				$taxonomies = get_option( CUSTOM_PTT_TAXONOMY_OPTION_NAME, array() );
+				wp_cache_set( 'registered_taxonomies', $taxonomies, self::CACHE_GROUP, HOUR_IN_SECONDS );
+			}
 
-		$taxonomies = get_option( CUSTOM_PTT_TAXONOMY_OPTION_NAME, array() );
-		if ( empty( $taxonomies ) ) {
-			return;
-		}
+			if ( empty( $taxonomies ) ) {
+				return;
+			}
 
-		foreach ( $taxonomies as $taxonomy_slug => $taxonomy_data ) {
-			$labels = array(
-				'name'          => $taxonomy_data['plural_label'],
-				'singular_name' => $taxonomy_data['singular_label'],
-			);
-
-			$args = array(
-				'labels'            => $labels,
-				'public'            => true,
-				'show_ui'           => true,
-				'show_in_menu'      => true,
-				'show_in_nav_menus' => true,
-				'show_in_rest'      => true,
-			);
-			$args = wp_parse_args( $taxonomy_data, $args );
+			foreach ( $taxonomies as $taxonomy_slug => $taxonomy_data ) {
+				try {
+					$this->register_single_taxonomy( $taxonomy_slug, $taxonomy_data );
+				} catch ( Exception $e ) {
+					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+						error_log(
+							sprintf( 
+								'Custom PTT Plugin - Error registering taxonomy %s: %s', 
+								$taxonomy_slug, 
+								$e->getMessage() 
+							) 
+						);
+					}
+					continue;
+				}
+			}
 
 			/**
-			 * Filters the arguments used when registering a taxonomy.
+			 * Fires after the taxonomies are registered.
 			 *
-			 * @param array $args The arguments used when registering a taxonomy.
-			 * @param string $taxonomy_slug The taxonomy slug.
-			 * @param array $taxonomy_data The taxonomy data.
+			 * @param array $taxonomies The taxonomies that were registered.
 			 * @since 0.1.0-alpha
 			 */
-			$args = apply_filters( 'custom_ptt_taxonomy_args', $args, $taxonomy_slug, $taxonomy_data );
+			do_action( 'custom_ptt_registered_taxonomies', $taxonomies );
 
-			$tax_result = register_taxonomy( $taxonomy_slug, $taxonomy_data['post_type'], $args );
-
-			if ( $tax_result instanceof WP_Error ) {
-				throw new Exception( $tax_result->get_error_message() );
+		} catch ( Exception $e ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log(
+					sprintf( 
+						'Custom PTT Plugin - Error in taxonomy registration process: %s', 
+						$e->getMessage() 
+					) 
+				);
 			}
+			throw $e;
 		}
+	}
+
+	/**
+	 * Register a single taxonomy.
+	 *
+	 * @param string $taxonomy_slug The taxonomy slug.
+	 * @param array  $taxonomy_data The taxonomy data.
+	 * @throws Exception If taxonomy registration fails.
+	 * @return void
+	 */
+	private function register_single_taxonomy( string $taxonomy_slug, array $taxonomy_data ): void {
+		$labels = array(
+			'name'          => $taxonomy_data['plural_label'],
+			'singular_name' => $taxonomy_data['singular_label'],
+		);
+
+		$args = array(
+			'labels'            => $labels,
+			'public'            => true,
+			'show_ui'           => true,
+			'show_in_menu'      => true,
+			'show_in_nav_menus' => true,
+			'show_in_rest'      => true,
+		);
+		
+		$args = wp_parse_args( $taxonomy_data, $args );
 
 		/**
-		 * Fires after the taxonomies are registered.
+		 * Filters the arguments used when registering a taxonomy.
 		 *
-		 * @param array $taxonomies The taxonomies that were registered.
+		 * @param array  $args          The arguments used when registering a taxonomy.
+		 * @param string $taxonomy_slug The taxonomy slug.
+		 * @param array  $taxonomy_data The taxonomy data.
 		 * @since 0.1.0-alpha
 		 */
-		do_action( 'custom_ptt_registered_taxonomies', $taxonomies );
+		$args = apply_filters( 'custom_ptt_taxonomy_args', $args, $taxonomy_slug, $taxonomy_data );
+		
+		$args_hash   = md5( serialize( $args ) );
+		$cache_key   = "taxonomy_{$taxonomy_slug}_{$args_hash}";
+		$cached_args = wp_cache_get( $cache_key, self::CACHE_GROUP );
+		
+		if ( false === $cached_args ) {
+			wp_cache_set( $cache_key, $args, self::CACHE_GROUP, HOUR_IN_SECONDS );
+		} else {
+			$args = $cached_args;
+		}
+
+		$tax_result = register_taxonomy( $taxonomy_slug, $taxonomy_data['post_type'], $args );
+
+		if ( $tax_result instanceof WP_Error ) {
+			throw new Exception( esc_html( $tax_result->get_error_message() ) );
+		}
 	}
 }

--- a/includes/Utilities.php
+++ b/includes/Utilities.php
@@ -9,9 +9,6 @@ namespace Custom_PTT;
  *
  * A collection of utility methods for the Custom PTT plugin.
  *
- * This trait provides utility methods that can be reused across different
- * classes within the Custom PTT plugin.
- *
  * @package Custom_PTT
  * @since 0.1.0-alpha
  */
@@ -25,13 +22,15 @@ trait Utilities {
 	 *
 	 * @param string $snake_case_string The snake_case string to be formatted.
 	 * @return string The formatted Title Case string.
+	 * @throws \InvalidArgumentException If string is empty.
 	 *
 	 * @since 0.1.0-alpha
 	 */
 	public function format_snake_case_to_title_case( string $snake_case_string ): string {
-		$words             = str_replace( '_', ' ', $snake_case_string );
-		$title_case_string = ucwords( $words );
+		if ( empty( $snake_case_string ) ) {
+			throw new \InvalidArgumentException( 'String cannot be empty' );
+		}
 
-		return $title_case_string;
+		return ucwords( str_replace( '_', ' ', $snake_case_string ) );
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,6 +22,9 @@
         <exclude name="WordPress.Files.FileName.InvalidClassFileName" />
     </rule>
 
+    <!-- Add VIP specific rules -->
+    <rule ref="WordPress-VIP-Go"/>
+
     <!-- Ensure PHP 8.0 compatibility -->
     <config name="testVersion" value="8.0" />
     <rule ref="PHPCompatibilityWP">


### PR DESCRIPTION

  🚨 Critical Fixes

  - 🔒 Prevent slug modification in edit mode to avoid data loss and duplicate registrations
    - Display post type/taxonomy slugs as read-only styled text boxes in edit mode
    - Maintain input functionality for creating new post types/taxonomies
    - Add contextual help text explaining permanent identifier behavior

  📋 WordPress.org Plugin Directory Compliance

  - ✅ Fix text domain inconsistencies from custom-post-types-post-types → custom-post-types-taxonomies
  - 🔐 Enhance security with proper input sanitization
    - Add wp_unslash() and sanitize_text_field() for all user inputs
    - Escape error message output with esc_html()
  - 📁 Create /languages directory to resolve domain path validation
  - 📖 Update README.md to WordPress.org standards
    - Add required plugin headers (Contributors, Tags, Tested up to, etc.)
    - Set "Tested up to: 6.8" and remove invalid tags
    - Convert to proper WordPress plugin readme format

  🎨 UX Improvements

  - 💅 Consistent TailwindCSS styling for read-only slug displays
  - 📝 Clear visual distinction between editable and informational fields
  - 💡 Helpful guidance text for better user understanding

  🎯 Impact

  - Prevents accidental data loss when editing existing post types/taxonomies
  - Ensures plugin passes WordPress.org submission requirements
  - Improves overall user experience and form clarity
